### PR TITLE
Add new options DeleteSoft and DeleteHard to rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Report Generator Tool generated website:
 TestCoverage/
+TestResults/
 
 # User-specific files
 *.suo

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Blazor.ExtraDry.Core.Tests.csproj
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Blazor.ExtraDry.Core.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Blazor.ExtraDry.Core\Blazor.ExtraDry.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class RuleEngineDeleteAsyncTests {
+
+        [Fact]
+        public async Task EntityFrameworkStyleDeleteSoftFailover()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var item = new object();
+            var items = new List<object> { item };
+            
+            await rules.DeleteSoftAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
+
+            Assert.Equal(SaveState.Done, state);
+        }
+
+        [Fact]
+        public async Task EntityFrameworkStyleHardDelete()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var item = new object();
+            var items = new List<object> { item };
+
+            await rules.DeleteHardAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
+
+            Assert.Equal(SaveState.Done, state);
+        }
+
+        private void SaveChanges()
+        {
+            state = SaveState.Processing;
+            state = SaveState.Done;
+        }
+
+        private async Task SaveChangesAsync()
+        {
+            state = SaveState.Processing;
+            await Task.Delay(1);
+            state = SaveState.Done;
+        }
+
+        private SaveState state = SaveState.Pending;
+
+        private enum SaveState {
+            Pending = 0,
+            Processing = 1,
+            Done = 2,
+        }
+
+        public class ServiceProviderStub : IServiceProvider {
+            public object GetService(Type serviceType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class SoftDeletable {
+            [Rules(DeleteValue = false)]
+            public bool Active { get; set; } = true;
+        }
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
@@ -57,7 +57,6 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             Assert.Empty(items);
         }
 
-
         [Fact]
         public void EntityFrameworkStyleHardDeleteSync()
         {
@@ -66,6 +65,44 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var items = new List<object> { item };
 
             rules.DeleteHard(item, () => items.Remove(item), () => SaveChanges());
+
+            Assert.Equal(SaveState.Done, state);
+            Assert.Empty(items);
+        }
+
+        [Fact]
+        public async Task EntityFrameworkStyleHardDeleteAsyncPrepare()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var item = new object();
+            var items = new List<object> { item };
+
+            await rules.DeleteHardAsync(item, 
+                async () => {
+                    await Task.Delay(1);
+                    items.Remove(item);
+                }, 
+                () => SaveChanges()
+            );
+
+            Assert.Equal(SaveState.Done, state);
+            Assert.Empty(items);
+        }
+
+        [Fact]
+        public async Task EntityFrameworkStyleDeleteSoftAsyncPrepare()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var item = new object();
+            var items = new List<object> { item };
+
+            await rules.DeleteSoftAsync(item,
+                async () => {
+                    await Task.Delay(1);
+                    items.Remove(item);
+                },
+                () => SaveChanges()
+            );
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class RuleEngineDeleteTests {
+
+        [Fact]
+        public void DeleteRequiresItem()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<ArgumentNullException>(() => rules.Delete((object)null, NoOp));
+        }
+
+        [Fact]
+        public void DeleteSoftDeletesByDefault()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var obj = new SoftDeletable();
+
+            rules.Delete(obj, null);
+
+            Assert.False(obj.Active);
+        }
+
+        [Fact]
+        public void DeleteHardDeleteBackup()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var obj = new SoftDeletable();
+            var deleted = false;
+
+            rules.Delete(new object(), () => deleted = true);
+
+            Assert.True(deleted);
+        }
+
+        [Fact]
+        public void DeleteSoftRequiresItem()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<ArgumentNullException>(() => rules.DeleteSoft((object)null, NoOp, NoOp));
+        }
+
+        [Fact]
+        public void DeleteSoftChangesActive()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var obj = new SoftDeletable();
+
+            rules.DeleteSoft(obj, NoOp, NoOp);
+
+            Assert.False(obj.Active);
+        }
+
+        [Fact]
+        public void DeleteSoftFallbackNotNull()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<InvalidOperationException>(
+                () => rules.DeleteSoft(new object(), null, null)
+            );
+        }
+
+        [Fact]
+        public void DeleteSoftFallbackExecutes()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var executed = false;
+
+            rules.DeleteSoft(new object(), () => executed = true, null);
+
+            Assert.True(executed);
+        }
+
+        [Fact]
+        public void DeleteSoftFallbackAndCommitExecutes()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var executed = false;
+            var committed = false;
+
+            rules.DeleteSoft(new object(), () => executed = true, () => committed = true);
+
+            Assert.True(executed);
+            Assert.True(committed);
+        }
+
+
+        [Fact]
+        public void DeleteHardRequiresItem()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<ArgumentNullException>(() => rules.DeleteHard((object)null, NoOp, NoOp));
+        }
+
+        [Fact]
+        public void DeleteHardRequiresPrepareAction()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<ArgumentNullException>(() => rules.DeleteHard(new object(), null, NoOp));
+        }
+
+        [Fact]
+        public void DeleteHardRequiresCommitAction()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<ArgumentNullException>(
+                () => rules.DeleteHard(new object(), NoOp, null)
+            );
+        }
+
+        [Fact]
+        public void DeleteHardPrepareCommitCycle()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            int prepared = 0;
+            int committed = 0;
+
+            rules.DeleteHard(new object(), () => FakePrepare(ref prepared), () => FakeCommit(ref committed));
+
+            Assert.Equal(1, prepared);
+            Assert.Equal(2, committed);
+        }
+
+        [Fact]
+        public void DeleteHardFailHardAndSoft()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            Assert.Throws<InvalidOperationException>(
+                () => rules.DeleteHard(new object(), NoOp, () => throw new NotImplementedException())
+            );
+        }
+
+        [Fact]
+        public void DeleteHardSoftFallback()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var obj = new SoftDeletable();
+
+            rules.DeleteHard(obj, NoOp,
+                () => { if(obj.Active == true) { throw new Exception(); } } // exception on hard delete, not after soft-delete; mimic EF .SaveChanges().
+            );
+
+            Assert.False(obj.Active);
+        }
+
+
+        private static void NoOp() { }
+
+        private void FakePrepare(ref int stepStamp) => stepStamp = step++;
+
+        private void FakeCommit(ref int stepStamp) => stepStamp = step++;
+
+        private int step = 1;
+
+        public class ServiceProviderStub : IServiceProvider {
+            public object GetService(Type serviceType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class SoftDeletable {
+            [Rules(DeleteValue = false)]
+            public bool Active { get; set; } = true;
+        }
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
@@ -155,7 +155,6 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             Assert.False(obj.Active);
         }
 
-
         private static void NoOp() { }
 
         private void FakePrepare(ref int stepStamp) => stepStamp = step++;

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteTests.cs
@@ -155,6 +155,20 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             Assert.False(obj.Active);
         }
 
+        [Fact]
+        public void SoftDeleteDoesntChangeOtherValues()
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var obj = new SoftDeletable();
+            var original = obj.Unchanged;
+            var unruled = obj.UnRuled;
+
+            rules.DeleteSoft(obj, NoOp, NoOp);
+
+            Assert.Equal(original, obj.Unchanged);
+            Assert.Equal(unruled, obj.UnRuled);
+        }
+
         private static void NoOp() { }
 
         private void FakePrepare(ref int stepStamp) => stepStamp = step++;
@@ -173,6 +187,11 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
         public class SoftDeletable {
             [Rules(DeleteValue = false)]
             public bool Active { get; set; } = true;
+
+            [Rules]
+            public int Unchanged { get; set; } = 2;
+
+            public int UnRuled { get; set; } = 3;
         }
 
     }

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core/Rules/RuleEngine.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core/Rules/RuleEngine.cs
@@ -311,11 +311,8 @@ namespace Blazor.ExtraDry {
 
         private static void CompleteActionMasquardingAsFuncTask(Task task)
         {
-            if(task.IsFaulted) {
+            if(task.IsCompleted && task.IsFaulted) {
                 throw task.Exception.InnerException;
-            }
-            if(!task.IsCompleted) {
-                task.RunSynchronously();
             }
         }
 

--- a/Blazor.ExtraDry/Blazor.ExtraDry.sln
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Client", "Sample.Cli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazor.ExtraDry.Tests", "Blazor.ExtraDry.Tests\Blazor.ExtraDry.Tests.csproj", "{DDB539A2-0653-4834-8B2A-F20991FCDC68}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazor.ExtraDry.Core.Tests", "Blazor.ExtraDry.Core.Tests\Blazor.ExtraDry.Core.Tests.csproj", "{301D6489-BA7B-45DE-89EA-21405C404D45}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{DDB539A2-0653-4834-8B2A-F20991FCDC68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDB539A2-0653-4834-8B2A-F20991FCDC68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDB539A2-0653-4834-8B2A-F20991FCDC68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{301D6489-BA7B-45DE-89EA-21405C404D45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{301D6489-BA7B-45DE-89EA-21405C404D45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{301D6489-BA7B-45DE-89EA-21405C404D45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{301D6489-BA7B-45DE-89EA-21405C404D45}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Blazor.ExtraDry/Blazor.ExtraDry/Models/ValueDescription.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry/Models/ValueDescription.cs
@@ -1,12 +1,7 @@
 ﻿#nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Blazor.ExtraDry {
     public class ValueDescription {

--- a/README.md
+++ b/README.md
@@ -71,3 +71,26 @@ Add a Razor page component that edits the item (examples assume T is `Item`)
 
      ```
 
+#### Code Coverage
+
+The coverlet collector has been added to the unit tests for the manual running of code coverage.  To run, install the following prerequisites.  These are global tools for dotnet core.  See https://github.com/danielpalme/ReportGenerator
+
+```
+dotnet tool install -g dotnet-reportgenerator-globaltool
+dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
+```
+
+Once installed, run code coverage statistics using dotnet as:
+
+```
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+This will store XML coverage files in the 'cobertura' file format.  These can be used by any tools that support that format, in particular the report generator that was installed in the global install steps above.
+
+From the project root directory, run the following to collect the cobertura files and create a static website and browse it:
+
+```
+reportgenerator -reports:./*/TestResults/*/*.xml -targetdir:./TestCoverage
+./TestCoverage/index.htm
+```


### PR DESCRIPTION
Add functionality that allows for a Hard Delete from database with a soft-delete backup when referential integrity is violated.  Only calls the functions in the correct order, doesn't take a dependency on any particular database or ORM.

Tests added that are specific to delete functionality, not backing filling rest of tests at this time.