### PR TITLE
Mock save changes to mimic referential integrity test

### DIFF
--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Blazor.ExtraDry.Core.Tests.csproj
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Blazor.ExtraDry.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/EntityFrameworkTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/EntityFrameworkTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class EntityFrameworkTests {
+
+        [Fact]
+        public async Task HardDeleteUserWithoutAddress() {
+            var database = GetPopulatedDatabase();
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var user = database.Users.First(e => e.Name == "Homeless");
+
+            await rules.DeleteHardAsync(user, () => database.Remove(user), async () => await MockSaveChangesAsync(database));
+
+            Assert.Equal(1, database.Users.Count());
+        }
+
+        [Fact]
+        public async Task HardDeleteUserWithAddress()
+        {
+            var database = GetPopulatedDatabase();
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var user = database.Users.First(e => e.Name == "Homebody");
+
+            await rules.DeleteHardAsync(user, () => database.Remove(user), async () => await MockSaveChangesAsync(database));
+
+            Assert.Equal(1, database.Users.Count());
+        }
+
+        [Fact]
+        public async Task HardDeleteAddressUserSoftDelete()
+        {
+            var database = GetPopulatedDatabase();
+            var rules = new RuleEngine(new ServiceProviderStub());
+            var address = database.Addresses.First(e => e.Line == "123 Any Street");
+
+            await rules.DeleteHardAsync(address, () => database.Remove(address), async () => await MockSaveChangesAsync(database));
+
+            Assert.Equal(2, database.Addresses.Count());
+        }
+
+
+        private async Task MockSaveChangesAsync(TestContext database)
+        {
+            var removing = database.ChangeTracker.Entries()
+                .Where(e => e.Entity is Address && e.State == EntityState.Deleted)
+                .Select(e => e.Entity as Address)
+                .ToList();
+            var riViolation = database.Users.Any(user => removing.Any(address => user.Address == address));
+            if(riViolation) {
+                throw new InvalidOperationException("Referential integrity violoated, can't delete addres when user referencing it.");
+            }
+            await database.SaveChangesAsync();
+        }
+
+
+        private TestContext GetDatabase()
+        {
+            var options = new DbContextOptionsBuilder<TestContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new TestContext(options);
+        }
+
+        private void PopulateSampleData(TestContext database)
+        {
+            database.Users.Add(new User { Name = "Homeless" });
+            var vacant = new Address { Line = "Vacant" };
+            database.Addresses.Add(vacant);
+            var address = new Address { Line = "123 Any Street" };
+            database.Addresses.Add(address);
+            var user = new User { Name = "Homebody", Address = address };
+            database.Users.Add(user);
+            database.SaveChangesAsync();
+        }
+
+        private TestContext GetPopulatedDatabase()
+        {
+            var database = GetDatabase();
+            PopulateSampleData(database);
+            return database;
+        }
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineDeleteAsyncTests.cs
@@ -13,10 +13,11 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new SoftDeletable();
             var items = new List<SoftDeletable> { item };
 
-            rules.Delete(item, () => items.Remove(item));
+            var result = rules.Delete(item, () => items.Remove(item));
 
             Assert.NotEmpty(items);
             Assert.False(item.Active);
+            Assert.Equal(DeleteResult.SoftDeleted, result);
         }
 
         [Fact]
@@ -26,9 +27,10 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
 
-            rules.Delete(item, () => items.Remove(item));
+            var result = rules.Delete(item, () => items.Remove(item));
 
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         [Fact]
@@ -38,10 +40,11 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
             
-            await rules.DeleteSoftAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
+            var result = await rules.DeleteSoftAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         [Fact]
@@ -51,10 +54,11 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
 
-            await rules.DeleteHardAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
+            var result = await rules.DeleteHardAsync(item, () => items.Remove(item), async () => await SaveChangesAsync());
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         [Fact]
@@ -64,10 +68,11 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
 
-            rules.DeleteHard(item, () => items.Remove(item), () => SaveChanges());
+            var result = rules.DeleteHard(item, () => items.Remove(item), () => SaveChanges());
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         [Fact]
@@ -77,7 +82,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
 
-            await rules.DeleteHardAsync(item, 
+            var result = await rules.DeleteHardAsync(item, 
                 async () => {
                     await Task.Delay(1);
                     items.Remove(item);
@@ -87,6 +92,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         [Fact]
@@ -96,7 +102,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var item = new object();
             var items = new List<object> { item };
 
-            await rules.DeleteSoftAsync(item,
+            var result = await rules.DeleteSoftAsync(item,
                 async () => {
                     await Task.Delay(1);
                     items.Remove(item);
@@ -106,6 +112,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
 
             Assert.Equal(SaveState.Done, state);
             Assert.Empty(items);
+            Assert.Equal(DeleteResult.HardDeleted, result);
         }
 
         private void SaveChanges()
@@ -127,13 +134,6 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             Pending = 0,
             Processing = 1,
             Done = 2,
-        }
-
-        public class ServiceProviderStub : IServiceProvider {
-            public object GetService(Type serviceType)
-            {
-                throw new NotImplementedException();
-            }
         }
 
         public class SoftDeletable {

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/ActiveType.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/ActiveType.cs
@@ -1,0 +1,13 @@
+﻿namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public enum ActiveType {
+
+        Pending,
+
+        Inactive,
+
+        Active,
+
+        Deleted,
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/Address.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/Address.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class Address {
+
+        [Key]
+        public int Id { get; set; }
+
+        [Rules(DeleteValue = ActiveType.Deleted)]
+        public ActiveType Active { get; set; } = ActiveType.Pending;
+
+        public string Line { get; set; }
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/ServiceProviderStub.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/ServiceProviderStub.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class ServiceProviderStub : IServiceProvider {
+        public object GetService(Type serviceType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/TestContext.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/TestContext.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class TestContext : DbContext {
+
+        public TestContext(DbContextOptions<TestContext> options) : base(options) { }
+
+        public DbSet<User> Users { get; set; }
+
+        public DbSet<Address> Addresses { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/User.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/SupportClasses/User.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazor.ExtraDry.Core.Tests.Rules {
+    public class User {
+
+        [Key]
+        public int Id { get; set; }
+
+        [Rules(DeleteValue = ActiveType.Deleted)]
+        public ActiveType Active { get; set; } = ActiveType.Pending;
+
+        public string Name { get; set; }
+
+        public Address Address { get; set; }
+
+    }
+}

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core/Rules/DeleteResult.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core/Rules/DeleteResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazor.ExtraDry {
+    public enum DeleteResult {
+
+        NotDeleted,
+
+        SoftDeleted,
+
+        HardDeleted,
+
+    }
+}


### PR DESCRIPTION
Mostly just a change to the DeleteSoftAsync and DeleteHardAsync method calls.  All tests passed, but then added in the assertions on the expected returned result so ended up touching almost all unit tests.  Then added in a few more unit tests to more accurately represent the entity framework use cases.
